### PR TITLE
Updated easyconfigs for Paraver and dependencies

### DIFF
--- a/easybuild/easyconfigs/p/Paraver/Paraver-4.5.6-foss-2015a.eb
+++ b/easybuild/easyconfigs/p/Paraver/Paraver-4.5.6-foss-2015a.eb
@@ -1,0 +1,33 @@
+# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+# License::   New BSD
+#
+# This work is based from experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+name = "Paraver"
+version = "4.5.6"
+
+homepage = 'http://www.bsc.es/computer-sciences/performance-tools/paraver'
+description = """A very powerful performance visualization and analysis tool based on
+ traces that can be used to analyse any information that is expressed on its input trace format.
+ Traces for parallel MPI, OpenMP and other programs can be genereated with Extrae."""
+
+toolchain = {'name': 'foss', 'version': '2015a'}
+
+compname = 'GCC'
+compver = '4.8.3'
+
+dependencies = [
+    ('wxPropertyGrid', '1.4.15', "", (compname, compver)),
+    ('Boost', '1.58.0', '-serial', (compname, compver)),
+]
+
+osdependencies = ['wxWidgets-ansi-devel']
+
+# http://www.bsc.es/computer-sciences/performance-tools/downloads
+# Requires input of email address for download
+sources = ['%(namelower)s-' + "sources" +'-%(version)s.tar.gz']
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/w/wxPropertyGrid/wxPropertyGrid-1.4.15-GCC-4.8.3.eb
+++ b/easybuild/easyconfigs/w/wxPropertyGrid/wxPropertyGrid-1.4.15-GCC-4.8.3.eb
@@ -1,0 +1,33 @@
+# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# Copyright:: Copyright 2013 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+# License::   New BSD
+#
+# This work is based from experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+easyblock = 'ConfigureMake'
+
+name = "wxPropertyGrid"
+version = "1.4.15"
+
+homepage = 'http://wxpropgrid.sourceforge.net/'
+description = """wxPropertyGrid is a property sheet control for wxWidgets. In other words, it is
+ a specialized two-column grid for editing properties such as strings, numbers, flagsets, string arrays, and colours."""
+
+toolchain = {'name': 'GCC', 'version': '4.8.3'}
+
+osdependencies = ['wxWidgets-ansi-devel']
+
+# http://prdownloads.sourceforge.net/wxpropgrid/wxpropgrid-1.4.15-src.tar.gz?download
+sources = ['wxpropgrid' + '-%(version)s-src.tar.gz']
+source_urls = ['http://prdownloads.sourceforge.net/wxpropgrid/']
+
+sanity_check_paths = {
+    'files': ["include/wx/propgrid/propgrid.h", "lib64/libwxcode_gtk2_propgrid-2.8.so"],
+    'dirs': []
+}
+
+parallel = 1
+
+moduleclass = 'devel'


### PR DESCRIPTION
Status after our meeting in Gent; for sure needs some cleanup and further testing, but may serve as a basis for updating the old configs

Note that Boost-1.58.0-GCC-4.8.3-serial.eb is provided by https://github.com/boegel/easybuild-easyconfigs/pull/17
