### PR TITLE
Add Shapely in GCC/8.3.0 as well

### DIFF
--- a/easybuild/easyconfigs/g/GEOS/GEOS-3.8.0-GCC-8.3.0-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/g/GEOS/GEOS-3.8.0-GCC-8.3.0-Python-3.7.4.eb
@@ -7,7 +7,7 @@ versionsuffix = '-Python-%(pyver)s'
 homepage = 'https://trac.osgeo.org/geos'
 description = """GEOS (Geometry Engine - Open Source) is a C++ port of the Java Topology Suite (JTS)"""
 
-toolchain = {'name': 'foss', 'version': '2019b'}
+toolchain = {'name': 'GCC', 'version': '8.3.0'}
 
 source_urls = ['https://download.osgeo.org/geos/']
 sources = [SOURCELOWER_TAR_BZ2]

--- a/easybuild/easyconfigs/s/Shapely/Shapely-1.7.0-GCC-8.3.0-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/s/Shapely/Shapely-1.7.0-GCC-8.3.0-Python-3.7.4.eb
@@ -1,0 +1,26 @@
+easyblock = 'PythonPackage'
+
+name = 'Shapely'
+version = '1.7.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://github.com/Toblerity/Shapely'
+description = """Shapely is a BSD-licensed Python package for manipulation and analysis of planar geometric objects.
+It is based on the widely deployed GEOS (the engine of PostGIS) and JTS (from which GEOS is ported) libraries."""
+
+toolchain = {'name': 'GCC', 'version': '8.3.0'}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+checksums = ['e21a9fe1a416463ff11ae037766fe410526c95700b9e545372475d2361cc951e']
+
+dependencies = [
+    ('Python', '3.7.4'),
+    ('GEOS', '3.8.0', versionsuffix),
+]
+
+download_dep_fail = True
+use_pip = True
+sanity_pip_check = True
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/s/Shapely/Shapely-1.7.0-iccifort-2019.5.281-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/s/Shapely/Shapely-1.7.0-iccifort-2019.5.281-Python-3.7.4.eb
@@ -5,7 +5,8 @@ version = '1.7.0'
 versionsuffix = '-Python-%(pyver)s'
 
 homepage = 'https://github.com/Toblerity/Shapely'
-description = "Shapely is a BSD-licensed Python package for manipulation and analysis of planar geometric objects."
+description = """Shapely is a BSD-licensed Python package for manipulation and analysis of planar geometric objects.
+It is based on the widely deployed GEOS (the engine of PostGIS) and JTS (from which GEOS is ported) libraries."""
 
 toolchain = {'name': 'iccifort', 'version': '2019.5.281'}
 


### PR DESCRIPTION
I was also working on Shapely but for the superior toolchain :smile: 
Do you mind adding this to your PR?

I'm also switching GEOS v3.8.0 from foss to GCC to be at the same level as GEOS-3.8.0-iccifort-2019.5. The easyconfig in foss/2019b has not hit master yet, so it can be fixed before next release.