### PR TITLE
Add patch for jaxlib 0.1.71 in jax 0.2.20 easyconfig to fix environment during build

### DIFF
--- a/easybuild/easyconfigs/j/jax/jax-0.2.20-foss-2021a.eb
+++ b/easybuild/easyconfigs/j/jax/jax-0.2.20-foss-2021a.eb
@@ -80,7 +80,7 @@ components = [
             # jaxlib-0.1.71_no-tensorflow-download.patch
             '693cff114553fa5591aa4cb3d777c9b7dea1ded1effef76d7d45d11cd2fc3819',
             # jaxlib-0.1.71_fix-llvm-env.patch
-            '9f1ee59ff7cfcfb272c4baebbc1c5b3b26fd9b9ddf05c1ffa77c8ebd2ba70b7e',
+            '73f5a83dd13c71cc1ed2c3db084a67861d418a8dd56d862cb2310a522de1a4ee',
         ],
         'start_dir': 'jax-jaxlib-v%(version)s',
         'prebuildopts': local_jax_prebuildopts,

--- a/easybuild/easyconfigs/j/jax/jax-0.2.20-foss-2021a.eb
+++ b/easybuild/easyconfigs/j/jax/jax-0.2.20-foss-2021a.eb
@@ -79,6 +79,8 @@ components = [
             'c0ea6abd7827d3c37bdd60c30c7b0613fc86b91274c6a1a4cf13a3c7f9ce7631',
             # jaxlib-0.1.71_no-tensorflow-download.patch
             '693cff114553fa5591aa4cb3d777c9b7dea1ded1effef76d7d45d11cd2fc3819',
+            # jaxlib-0.1.71_fix-llvm-env.patch
+            '9f1ee59ff7cfcfb272c4baebbc1c5b3b26fd9b9ddf05c1ffa77c8ebd2ba70b7e',
         ],
         'start_dir': 'jax-jaxlib-v%(version)s',
         'prebuildopts': local_jax_prebuildopts,

--- a/easybuild/easyconfigs/j/jax/jax-0.2.20-foss-2021a.eb
+++ b/easybuild/easyconfigs/j/jax/jax-0.2.20-foss-2021a.eb
@@ -97,6 +97,4 @@ exts_list = [
     }),
 ]
 
-sanity_pip_check = True
-
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/j/jax/jax-0.2.20-foss-2021a.eb
+++ b/easybuild/easyconfigs/j/jax/jax-0.2.20-foss-2021a.eb
@@ -32,6 +32,7 @@ local_tf_builddir = '%(builddir)s/' + local_tf_dir
 local_jax_prebuildopts = "sed -i 's$pathToSed$%s$g' WORKSPACE && " % local_tf_builddir
 
 use_pip = True
+sanity_pip_check = True
 
 # running the tests with lots of cores results in test failures because not enough threads can be started,
 # so limit to a reasonable number of cores to use at maximum
@@ -67,6 +68,7 @@ components = [
         'patches': [
             'jaxlib-0.1.70_add-bazel-args-to-shutdown.patch',
             'jaxlib-%(version)s_no-tensorflow-download.patch',
+            ('jaxlib-%(version)s_fix-llvm-env.patch', '../' + local_tf_dir),
         ],
         'checksums': [
             # jaxlib-v0.1.71.tar.gz

--- a/easybuild/easyconfigs/j/jax/jaxlib-0.1.71_fix-llvm-env.patch
+++ b/easybuild/easyconfigs/j/jax/jaxlib-0.1.71_fix-llvm-env.patch
@@ -1,0 +1,28 @@
+diff --git a/third_party/llvm/workspace.bzl b/third_party/llvm/workspace.bzl
+index c0c7ef3db29..63ccda6dc65 100644
+--- a/third_party/llvm/workspace.bzl
++++ b/third_party/llvm/workspace.bzl
+@@ -16,4 +16,5 @@ def repo(name):
+             "https://github.com/llvm/llvm-project/archive/{commit}.tar.gz".format(commit = LLVM_COMMIT),
+         ],
+         build_file = "//third_party/llvm:BUILD.bazel",
++        patch_file = "//third_party/llvm:fix-ctx.run.patch",
+     )
+diff --git a/third_party/llvm/fix-ctx.run.patch b/third_party/llvm/fix-ctx.run.patch
+new file mode 100644
+index 00000000000..65aff1fcd3f
+--- /dev/null
++++ b/third_party/llvm/fix-ctx.run.patch
+@@ -0,0 +1,12 @@
++diff --git a/utils/bazel/llvm-project-overlay/mlir/tblgen.bzl b/utils/bazel/llvm-project-overlay/mlir/tblgen.bzl
++index 64685aa1cbc10..177789797a3e0 100644
++--- a/utils/bazel/llvm-project-overlay/mlir/tblgen.bzl
+++++ b/utils/bazel/llvm-project-overlay/mlir/tblgen.bzl
++@@ -169,6 +169,7 @@ def _gentbl_rule_impl(ctx):
++         inputs = trans_srcs,
++         executable = ctx.executable.tblgen,
++         arguments = [args],
+++        use_default_shell_env = True,
++         mnemonic = "TdGenerate",
++     )
++ 

--- a/easybuild/easyconfigs/j/jax/jaxlib-0.1.71_fix-llvm-env.patch
+++ b/easybuild/easyconfigs/j/jax/jaxlib-0.1.71_fix-llvm-env.patch
@@ -1,3 +1,8 @@
+Enable use_default_shell_env for the MLIR table generator so that the environment (action_env etc.) is correctly passed to the tool
+See https://github.com/google/jax/issues/7842
+
+Author: Alexander Grund (TU Dresden)
+
 diff --git a/third_party/llvm/workspace.bzl b/third_party/llvm/workspace.bzl
 index c0c7ef3db29..63ccda6dc65 100644
 --- a/third_party/llvm/workspace.bzl


### PR DESCRIPTION
Basically applies my proposed change from https://reviews.llvm.org/D109873

edit: for https://github.com/easybuilders/easybuild-easyconfigs/pull/14003