### PR TITLE
Disable TestF90Callback since it fails with Intel.

### DIFF
--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2021.05-intel-2021a.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2021.05-intel-2021a.eb
@@ -25,6 +25,7 @@ exts_list = [
             'numpy-1.18.2-mkl.patch',
             'numpy-1.20.3_disable-broken-override-test.patch',
             'numpy-1.20.3_fix-cpu-feature-detection-intel-compilers.patch',
+            'numpy-1.20.3_disable_fortran_callback_test.patch',
         ],
         'source_tmpl': '%(name)s-%(version)s.zip',
         'checksums': [
@@ -34,6 +35,8 @@ exts_list = [
             '43cc2e675c52db1776efcc6c84ebd5fc008b48e6355c81087420d5e790e4af9b',
             # numpy-1.20.3_fix-cpu-feature-detection-intel-compilers.patch
             '4c0b194c9d2e2c6b9798ebc271d4517f4c3cdbf2b3cbd68de16c7d4b068bb046',
+            # numpy-1.20.3_disable_fortran_callback_test.patch
+            '44975a944544fd0e771b7e63c32590d257a3713070f8f7fdf60105dc516f1d75',
         ],
     }),
     ('scipy', '1.6.3', {

--- a/easybuild/easyconfigs/s/SciPy-bundle/numpy-1.20.3_disable_fortran_callback_test.patch
+++ b/easybuild/easyconfigs/s/SciPy-bundle/numpy-1.20.3_disable_fortran_callback_test.patch
@@ -1,0 +1,17 @@
+Disable TestF90Callback which fails when compiling the resulting code with ifort.
+The resulting code is incorrect Fortran.
+See https://github.com/numpy/numpy/issues/20157
+
+Åke Sandgren, 20211021
+diff -ru numpy-1.20.3.orig/numpy/f2py/tests/test_callback.py numpy-1.20.3/numpy/f2py/tests/test_callback.py
+--- numpy-1.20.3.orig/numpy/f2py/tests/test_callback.py	2021-05-08 23:14:06.000000000 +0200
++++ numpy-1.20.3/numpy/f2py/tests/test_callback.py	2021-10-21 19:05:32.463548952 +0200
+@@ -261,7 +261,7 @@
+     options = ["-DF2PY_USE_PYTHON_TLS"]
+ 
+ 
+-class TestF90Callback(util.F2PyTest):
++class Disabled_for_intel_TestF90Callback(util.F2PyTest):
+ 
+     suffix = '.f90'
+ 


### PR DESCRIPTION
The produced Fortran code is incorrect.