### PR TITLE
Adjust version of backports.entry_points_selectable

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-2.7.18-GCCcore-11.2.0.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.18-GCCcore-11.2.0.eb
@@ -173,8 +173,8 @@ exts_list = [
     ('platformdirs', '2.0.2', {
         'checksums': ['3b00d081227d9037bbbca521a5787796b5ef5000faea1e43fd76f1d44b06fcfa'],
     }),
-    ('backports.entry_points_selectable', '1.1.1', {
-        'checksums': ['914b21a479fde881635f7af5adc7f6e38d6b274be32269070c53b698c60d5386'],
+    ('backports.entry_points_selectable', '1.1.0', {
+        'checksums': ['988468260ec1c196dab6ae1149260e2f5472c9110334e5d51adcb77867361f6a'],
     }),
     ('virtualenv', '20.7.0', {
         'checksums': ['97066a978431ec096d163e72771df5357c5c898ffdd587048f45e0aecc228094'],


### PR DESCRIPTION
make Python-2.7.18-GCCcore-11.2.0.eb match Python-3.9.6-GCCcore-11.2.0.eb