### PR TITLE
Adjust disable-fma-in-cscal-zscal.patch for GCC 12

### DIFF
--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.21-GCC-12.2.0.eb
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.21-GCC-12.2.0.eb
@@ -17,7 +17,7 @@ patches = [
     ('timing.tgz', '.'),
     'OpenBLAS-0.3.15_workaround-gcc-miscompilation.patch',
     'OpenBLAS-0.3.21_fix-order-vectorization.patch',
-    'OpenBLAS-0.3.21_disable-fma-in-cscal-zscal.patch',
+    'OpenBLAS-0.3.21-GCC-12.2.0_disable-fma-in-cscal-zscal.patch',
     'OpenBLAS-0.3.21_avoid-crash-in-zdot.patch',
 ]
 checksums = [
@@ -28,8 +28,8 @@ checksums = [
      'e6b326fb8c4a8a6fd07741d9983c37a72c55c9ff9a4f74a80e1352ce5f975971'},
     {'OpenBLAS-0.3.21_fix-order-vectorization.patch':
      '08af834e5d60441fd35c128758ed9c092ba6887c829e0471ecd489079539047d'},
-    {'OpenBLAS-0.3.21_disable-fma-in-cscal-zscal.patch':
-     'bd6836206a883208dc8bc997946f97e4c97d91d8e101fc54db414aaa56902fc3'},
+    {'OpenBLAS-0.3.21-GCC-12.2.0_disable-fma-in-cscal-zscal.patch':
+     '9784e93567d100960a4c34d86e215bd7aa70bb28b0bc2c6bf1b22c6a05d56003'},
     {'OpenBLAS-0.3.21_avoid-crash-in-zdot.patch': '3dac2c1ec896df574f1b37cde81a16f24550b7f1eb81fbfacb0c4449b0dc7894'},
 ]
 

--- a/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.21-GCC-12.2.0_disable-fma-in-cscal-zscal.patch
+++ b/easybuild/easyconfigs/o/OpenBLAS/OpenBLAS-0.3.21-GCC-12.2.0_disable-fma-in-cscal-zscal.patch
@@ -1,0 +1,73 @@
+From e7e3aa29482281edba46a27fcd452d7ed630f46a Mon Sep 17 00:00:00 2001
+From: Bart Oldeman <bartoldeman@users.noreply.github.com>
+Date: Thu, 27 Oct 2022 17:20:44 -0400
+Subject: [PATCH] x86_64: prevent GCC and Clang from generating FMAs in
+ cscal/zscal.
+
+If e.g. -march=haswell is set in CFLAGS, GCC generates FMAs by default, which
+is inconsistent with the microkernels, none of which use FMAs. These
+inconsistencies cause a few failures in the LAPACK testcases, where
+eigenvalue results with/without eigenvectors are compared.
+
+Moreover using FMAs for multiplication of complex numbers can give surprising
+results, see 22aa81f for more information.
+
+This uses the same syntax as used in 22aa81f for zarch (s390x).
+
+Edit: 2022-11-11: add no-fma target since fp-contract=off isn't sufficient for
+GCC 12.2.
+---
+ kernel/x86_64/cscal.c | 14 +++++++++++++
+ kernel/x86_64/zscal.c | 14 +++++++++++++
+ 2 files changed, 28 insertions(+)
+
+diff --git a/kernel/x86_64/cscal.c b/kernel/x86_64/cscal.c
+index dc3f688c69..6ae66d9731 100644
+--- a/kernel/x86_64/cscal.c
++++ b/kernel/x86_64/cscal.c
+@@ -25,6 +25,20 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
+ 
++/*
++ * Avoid contraction of floating point operations, specifically fused
++ * multiply-add, because they can cause unexpected results in complex
++ * multiplication.
++ */
++#if defined(__GNUC__) && !defined(__clang__)
++#pragma GCC optimize ("fp-contract=off")
++#pragma GCC target ("no-fma")
++#endif
++
++#if defined(__clang__)
++#pragma clang fp contract(off)
++#endif
++
+ #include "common.h"
+ 
+ 
+diff --git a/kernel/x86_64/zscal.c b/kernel/x86_64/zscal.c
+index 3744c98bb7..dfdb4230b6 100644
+--- a/kernel/x86_64/zscal.c
++++ b/kernel/x86_64/zscal.c
+@@ -25,6 +25,20 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
+ 
++/*
++ * Avoid contraction of floating point operations, specifically fused
++ * multiply-add, because they can cause unexpected results in complex
++ * multiplication.
++ */
++#if defined(__GNUC__) && !defined(__clang__)
++#pragma GCC optimize ("fp-contract=off")
++#pragma GCC target ("no-fma")
++#endif
++
++#if defined(__clang__)
++#pragma clang fp contract(off)
++#endif
++
+ #include "common.h"
+ 
+ 


### PR DESCRIPTION
For some reason (GCC bug report pending) -ffp-contract=off is not sufficient for GCC 12, so we also need -mno-fma, implemented via a GCC pragma.